### PR TITLE
remove openshift-acme

### DIFF
--- a/app-interface-services/openshift-acme.yaml
+++ b/app-interface-services/openshift-acme.yaml
@@ -1,6 +1,0 @@
-services:
-- hash: ignore
-  name: openshift-acme
-  path: /openshift/openshift-acme.template.yaml
-  url: https://github.com/app-sre/openshift-acme-templates
-  hash_length: 7


### PR DESCRIPTION
openshift-acme is now managed via an integration, no need to deploy it through saasherder.