### PR TITLE
[qontract-server] set memory limit to 1Gi

### DIFF
--- a/app-interface-services/app-interface.yaml
+++ b/app-interface-services/app-interface.yaml
@@ -3,6 +3,7 @@ services:
   - name: production
     parameters:
       IMAGE_GATE_TAG: 89fffba
+      MEMORY_LIMIT: 1Gi
   - name: staging
     parameters:
       IMAGE_GATE_TAG: 89fffba


### PR DESCRIPTION
default value is 512Mi and the container is being OOMKilled