### PR TITLE
Adjusting github-mirror url

### DIFF
--- a/qontract-reconcile-services/qontract-reconcile.yaml
+++ b/qontract-reconcile-services/qontract-reconcile.yaml
@@ -3,14 +3,14 @@ services:
   - name: production
     parameters:
       DRY_RUN: --no-dry-run
-      GITHUB_API: http://github-mirror.github-mirror-production.svc.cluster.local
+      GITHUB_API: https://github-mirror.devshift.net
       SLACK_CHANNEL: sd-app-sre-reconcile
       SLEEP_DURATION_SECS: 120
       USER_ID: 1000640000
   - name: staging
     parameters:
       DRY_RUN: --dry-run
-      GITHUB_API: http://github-mirror.github-mirror-stage.svc.cluster.local
+      GITHUB_API: https://github-mirror.stage.devshift.net
       SLACK_CHANNEL: sd-app-sre-reconcile-stage
       SLEEP_DURATION_SECS: 600
       USER_ID: 1000720000


### PR DESCRIPTION
PyGithub got stricter about the URL matching between the base_url and
the next urls in a pagination. Let's use the standard base_url.

Signed-off-by: Amador Pahim <apahim@redhat.com>