### PR TITLE
depracation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# saas-app-interface
+
+This repository is now depracated in favor of https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/data/services/app-interface/cicd/ci-ext/saas.yaml.


### PR DESCRIPTION
deprecating this repository in favor of https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/data/services/app-interface/cicd/ci-ext/saas.yaml.